### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -1,4 +1,7 @@
 name: Pull Request Stats
+permissions:
+  contents: read
+  pull-requests: write
 on:
   pull_request:
     types: [opened]


### PR DESCRIPTION
Potential fix for [https://github.com/KINGINKOSI/gaaius-wallet/security/code-scanning/9](https://github.com/KINGINKOSI/gaaius-wallet/security/code-scanning/9)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function. Based on the workflow's purpose (running pull request stats), it likely only needs read access to the repository contents and possibly write access to pull requests. We will set `contents: read` and `pull-requests: write` as the permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
