### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -1,5 +1,7 @@
 name: Run CheckStyle
 on: pull_request, merge_group
+permissions:
+  contents: read
 
 jobs:
   checkstyle_job:


### PR DESCRIPTION
Potential fix for [https://github.com/KINGINKOSI/gaaius-wallet/security/code-scanning/1](https://github.com/KINGINKOSI/gaaius-wallet/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow primarily reads repository contents and uses the `GITHUB_TOKEN` for CheckStyle operations, the permissions should be limited to `contents: read`. This ensures that the workflow adheres to the principle of least privilege while still functioning correctly.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or specifically to the `checkstyle_job` job. In this case, adding it at the root level is sufficient and ensures consistency across all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
