### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Unit test(MacOS)
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/KINGINKOSI/gaaius-wallet/security/code-scanning/2](https://github.com/KINGINKOSI/gaaius-wallet/security/code-scanning/2)

To fix the issue, add a `permissions` block to the workflow. Since the workflow primarily reads repository contents and uploads artifacts, the permissions can be limited to `contents: read`. This ensures the `GITHUB_TOKEN` has only the minimal access required to complete the tasks.

The `permissions` block should be added at the root level of the workflow to apply to all jobs. Alternatively, it can be added to the specific job (`test`) if different jobs require different permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
