### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -1,4 +1,7 @@
 name: Unit test(Ubuntu)
+permissions:
+  contents: read
+  actions: write
 on:
   push:
     branches:

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -1,4 +1,6 @@
 name: Unit test(Windows)
+permissions:
+  contents: read
 on:
   push:
     branches:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,6 @@
 name: E2e Test
+permissions:
+  contents: read
 on:
   push:
     branches:

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,5 +1,8 @@
 name: Comments Android lint warnings on pull request
 on: pull_request
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   lint:
     name: Comments lint result on PR

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -1,4 +1,7 @@
 name: Pull Request Stats
+permissions:
+  contents: read
+  pull-requests: write
 on:
   pull_request:
     types: [opened]


### PR DESCRIPTION
Potential fix for [https://github.com/KINGINKOSI/gaaius-wallet/security/code-scanning/4](https://github.com/KINGINKOSI/gaaius-wallet/security/code-scanning/4)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the least privileges required for the workflow. Based on the tasks in the workflow:
- `contents: read` is sufficient for most steps, such as checking out the repository and running tests.
- `actions: write` is required for uploading artifacts.
- No other permissions appear to be necessary.

The `permissions` block should be added at the top level of the workflow file, ensuring it applies to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
