### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -1,4 +1,6 @@
 name: Unit test(Windows)
+permissions:
+  contents: read
 on:
   push:
     branches:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,6 @@
 name: E2e Test
+permissions:
+  contents: read
 on:
   push:
     branches:

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,5 +1,8 @@
 name: Comments Android lint warnings on pull request
 on: pull_request
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   lint:
     name: Comments lint result on PR

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: Android lint
+permissions:
+  contents: read
 on:
   push:
     branches:

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -1,4 +1,7 @@
 name: Pull Request Stats
+permissions:
+  contents: read
+  pull-requests: write
 on:
   pull_request:
     types: [opened]


### PR DESCRIPTION
Potential fix for [https://github.com/KINGINKOSI/gaaius-wallet/security/code-scanning/7](https://github.com/KINGINKOSI/gaaius-wallet/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Based on the workflow's steps, it primarily interacts with the repository's contents (e.g., checking out code and running linting tools). Therefore, we will set `contents: read` as the permission. This ensures that the `GITHUB_TOKEN` has only read access to the repository's contents and no write access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
