### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   merge_group:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run E2E Tests


### PR DESCRIPTION
Potential fix for [https://github.com/KINGINKOSI/gaaius-wallet/security/code-scanning/13](https://github.com/KINGINKOSI/gaaius-wallet/security/code-scanning/13)

To fix the issue, add an explicit `permissions` block to the workflow. Since the workflow primarily reads repository contents and uploads artifacts, the permissions can be limited to `contents: read`. This ensures that the `GITHUB_TOKEN` has only the minimum required access.

The `permissions` block should be added at the root level of the workflow to apply to all jobs. Alternatively, permissions can be defined for individual jobs if different levels of access are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
